### PR TITLE
Add missing region codes + Remove incorrect ones

### DIFF
--- a/specific-guide/sfx/basic-information.md
+++ b/specific-guide/sfx/basic-information.md
@@ -15,25 +15,26 @@ League of Legends, like many games, have a complex yet effective system to compr
 For sound modding in League of Legends we use these type of files:
 - **.wad.client**: Combination of compressed files that is used to hold multiple files at once (not only used for sounds (every mod for a champion changs some of these files)). For sound modding, this compression system is what holds **Champions Sound Effects**. There is a variation of these files that has a language prefix before ".wad" (**en_US.wad.client**; *en_US* being the prefix for the english language) that is used to contain every **Voice Line** for the champion in that specific language.
 Here is a list of every prefix used and their respective language.
-> ja_JP: Japanese
-ko_KR: Korean
-zh_CN: Chinese
-zh_TW: Taiwanese
+> ar_AE: Arabic
+cs_CZ: Czech
+de_DE: German
+el_GR: Greek
+en_US: English (Used by all English languages, as well as id_ID: Indonesian, and zh_MY: Malaysian)
 es_ES: Spanish (Spain)
 es_MX: Spanish (Mexico)
-en_US: English (USA)
-en_GB: English (Great Britain)
-en_AU: English (Australia)
 fr_FR: French
-de_DE: German
-it_IT: Italian
-pl_PL: Polish
-ro_RO: Romanian
-el_GR: Greek
-pt_BR: Portuguese
 hu_HU: Hungarian
+it_IT: Italian
+ja_JP: Japanese
+ko_KR: Korean
+pl_PL: Polish
+pt_BR: Portuguese
+ro_RO: Romanian
 ru_RU: Russian
 tr_TR: Turkish
+vi_VN: Vietnamese
+zh_CN: Chinese
+zh_TW: Taiwanese
 
 > To see any of this game files you have to have downloaded that version of the game (in the Riot Client go to settings and change the language for League of Legends. select and download the version that you want and go into a game)
 {.is-warning}

--- a/specific-guide/sfx/basic-information.md
+++ b/specific-guide/sfx/basic-information.md
@@ -19,7 +19,7 @@ Here is a list of every prefix used and their respective language.
 cs_CZ: Czech
 de_DE: German
 el_GR: Greek
-en_US: English (Used by all English languages, as well as id_ID: Indonesian, and zh_MY: Malaysian)
+en_US: English (Used by all English regions, as well as Indonesian, and Malaysian)
 es_ES: Spanish (Spain)
 es_MX: Spanish (Mexico)
 fr_FR: French
@@ -36,10 +36,10 @@ vi_VN: Vietnamese
 zh_CN: Chinese
 zh_TW: Taiwanese
 
-> To see any of this game files you have to have downloaded that version of the game (in the Riot Client go to settings and change the language for League of Legends. select and download the version that you want and go into a game)
+> To see any of these game files, you have to have downloaded that version of the game. (In the Riot Client, go to settings and change the language for League of Legends. Select and download the version that you want, then go into any game, like Practice Tool or Customs.)
 {.is-warning}
 
 - .wav: Generic audio file format used before converting into the format that League of Legends can read.
-- .wem: File format that the game reads. You can not use any other type of audio format to replace sounds
-- .bin: Code that reads every .wem file and makes the logic to get it to work in game; something like the brain of the game. (Not only used for sounds)
+- .wem: File format that the game reads. You can not use any other type of audio format to replace sounds.
+- .bin: Code that reads every .wem file and makes the logic to get it to work in game; Something like the brain of the game. (Not only used for sounds)
 - .bnk: Format that contains all the compressed .wem files that a model can have. There are two distinctions of the formats: "events.bnk" and "audio.bnk"


### PR DESCRIPTION
Added the missing audio region codes, as well as organized them alphabetically by region code. 
Removed en_GB and en_AU as those use the en_US file.

The only thing is I'm not sure if my explanation for the English code is too long for the box.

An extra note: en_US is valid for client regions: "en_AU", "en_GB", "en_PH", "en_SG", "en_US", "id_ID", and "zh_MY". This can be added somewhere if needed, but I figured "every English region + Indonesia and Malaysia" was sufficient.